### PR TITLE
Add the authors option

### DIFF
--- a/Easkfile
+++ b/Easkfile
@@ -1,5 +1,5 @@
 (package "magit-standup"
-         "0.1.0"
+         "0.2.0"
          "Collect recent git commits for standup notes")
 
 (website-url "https://github.com/function-artisans/magit-standup")

--- a/magit-standup.el
+++ b/magit-standup.el
@@ -244,7 +244,7 @@ Returns an alist of (REPO-PATH . BRANCH-COMMITS) suitable for
 (defun magit-standup-quit ()
   "Quit the `*magit-standup*' buffer and kill it."
   (interactive)
-  (when-let ((win (get-buffer-window magit-standup--buffer-name)))
+  (when-let* ((win (get-buffer-window magit-standup--buffer-name)))
     (quit-window t win)))
 
 (defun magit-standup--display (repo-commits)
@@ -269,7 +269,7 @@ REPO-COMMITS is an alist as returned by `magit-standup--gather'."
   "Return resolved repo paths as a list of normalized directory names."
   (mapcar (lambda (d) (directory-file-name (expand-file-name d)))
           (or (magit-standup--resolve-repos magit-standup-repos)
-              (when-let ((top (magit-toplevel)))
+              (when-let* ((top (magit-toplevel)))
                 (list top)))))
 
 (defun magit-standup--read-repos (prompt _initial-input _history)

--- a/magit-standup.el
+++ b/magit-standup.el
@@ -182,7 +182,7 @@ Returns an alist of (BRANCH-NAME . COMMITS) where COMMITS is a
 list of raw commit strings with hash and message separated by a
 null byte."
   (let* ((default-directory (file-name-as-directory repo-path))
-         (authors (magit-standup--resolve-authors repo-path authors))
+         (author-list (magit-standup--resolve-authors repo-path authors))
          (branches (magit-git-lines "branch" "--format=%(refname:short)")))
     (mapcar (lambda (branch)
               (cons branch
@@ -192,7 +192,7 @@ null byte."
                                      (concat "--after=" since-date)
                                      (mapcar (lambda (author)
                                                (concat "--author=" author))
-                                             authors)
+                                             author-list)
                                      branch)))
             branches)))
 
@@ -330,9 +330,9 @@ PROMPT is shown to the user.  Returns a comma-separated string."
          (repos-str (transient-arg-value "--repos=" args))
          (repos (when repos-str (split-string repos-str ",")))
          (authors-str (transient-arg-value "--authors=" args))
-         (authors (when authors-str (split-string authors-str "," t))))
+         (author-list (when authors-str (split-string authors-str "," t))))
     (magit-standup--display
-     (magit-standup--gather since repos authors))))
+     (magit-standup--gather since repos author-list))))
 
 ;;;###autoload (autoload 'magit-standup "magit-standup" nil t)
 (transient-define-prefix magit-standup ()

--- a/magit-standup.el
+++ b/magit-standup.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2026 Function Artisans, Ltd.
 
 ;; Author: István Karaszi <ikaraszi@gmail.com>
-;; Version: 0.1.0
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "28.1") (magit "4.5.0") (transient "0.8.0"))
 ;; Keywords: tools, vc
 ;; URL: https://github.com/function-artisans/magit-standup

--- a/magit-standup.el
+++ b/magit-standup.el
@@ -62,14 +62,17 @@ When nil, search with unlimited depth."
           (integer :tag "Max depth"))
   :group 'magit-standup)
 
-(defcustom magit-standup-author nil
-  "Author name or email to filter commits by.
-When nil, the result of `git config user.email' is used.  The
-`--author=' option of the `magit-standup' menu overrides this
-value for one run.  Git applies `.mailmap' to the filter, so use
-the mapped identity when a repository has a `.mailmap' file."
-  :type '(choice (const :tag "From git config" nil)
-          (string :tag "Author name/email"))
+(define-obsolete-variable-alias 'magit-standup-author
+  'magit-standup-authors "0.2.0")
+
+(defcustom magit-standup-authors nil
+  "List of author names or emails to filter commits by.
+Git keeps a commit when it matches one of the entries.  When nil,
+the result of `git config user.email' is used.  The `--authors='
+option of the `magit-standup' menu overrides this list for one
+run.  Git applies `.mailmap' to the filter, so use the mapped
+identity when a repository has a `.mailmap' file."
+  :type '(repeat (string :tag "Author name/email"))
   :group 'magit-standup)
 
 (defcustom magit-standup-link-package nil
@@ -160,24 +163,26 @@ the org link prefix string, or nil for plain text."
               hash)
             rest)))
 
-(defun magit-standup--resolve-author (repo-path &optional author)
-  "Return the author string to filter commits by in REPO-PATH.
-Uses AUTHOR if set, then `magit-standup-author', otherwise falls
-back to `git config user.email' in REPO-PATH."
+(defun magit-standup--resolve-authors (repo-path &optional authors)
+  "Return the list of authors to filter commits by in REPO-PATH.
+Uses AUTHORS if set, then `magit-standup-authors', otherwise falls
+back to `git config user.email' in REPO-PATH.  A single string
+gives a list of one entry."
   (let ((default-directory (file-name-as-directory repo-path)))
-    (or author
-        magit-standup-author
-        (magit-git-string "config" "user.email")
-        (user-error "Cannot determine author for %s; set `magit-standup-author' or git config user.email" repo-path))))
+    (or (ensure-list authors)
+        (ensure-list magit-standup-authors)
+        (when-let* ((email (magit-git-string "config" "user.email")))
+          (list email))
+        (user-error "Cannot determine author for %s; set `magit-standup-authors' or git config user.email" repo-path))))
 
-(defun magit-standup--collect-commits (repo-path since-date &optional author)
+(defun magit-standup--collect-commits (repo-path since-date &optional authors)
   "Collect commits from REPO-PATH since SINCE-DATE.
-AUTHOR, when non-nil, overrides `magit-standup-author'.
+AUTHORS, when non-nil, overrides `magit-standup-authors'.
 Returns an alist of (BRANCH-NAME . COMMITS) where COMMITS is a
 list of raw commit strings with hash and message separated by a
 null byte."
   (let* ((default-directory (file-name-as-directory repo-path))
-         (author (magit-standup--resolve-author repo-path author))
+         (authors (magit-standup--resolve-authors repo-path authors))
          (branches (magit-git-lines "branch" "--format=%(refname:short)")))
     (mapcar (lambda (branch)
               (cons branch
@@ -185,7 +190,9 @@ null byte."
                                      "--no-merges"
                                      "--format=%h%x00%s <%ai> - %aN"
                                      (concat "--after=" since-date)
-                                     (concat "--author=" author)
+                                     (mapcar (lambda (author)
+                                               (concat "--author=" author))
+                                             authors)
                                      branch)))
             branches)))
 
@@ -225,11 +232,11 @@ LINK-PREFIX is the org link prefix string, or nil for plain text."
                  (mapconcat #'identity formatted "\n")))))
    repo-commits ""))
 
-(defun magit-standup--gather (&optional since-date repos author)
+(defun magit-standup--gather (&optional since-date repos authors)
   "Gather recent commits across all configured repositories.
 SINCE-DATE, when non-nil, overrides the computed since date.
 REPOS, when non-nil, overrides `magit-standup-repos'.
-AUTHOR, when non-nil, overrides `magit-standup-author'.
+AUTHORS, when non-nil, overrides `magit-standup-authors'.
 Returns an alist of (REPO-PATH . BRANCH-COMMITS) suitable for
 `magit-standup--format-org'."
   (let* ((since-date (or since-date (magit-standup--since-date)))
@@ -238,7 +245,7 @@ Returns an alist of (REPO-PATH . BRANCH-COMMITS) suitable for
                     (list (magit-toplevel)))))
     (mapcar (lambda (repo)
               (cons repo
-                    (magit-standup--collect-commits repo since-date author)))
+                    (magit-standup--collect-commits repo since-date authors)))
             repos)))
 
 (defun magit-standup-quit ()
@@ -294,14 +301,24 @@ PROMPT is shown to the user.  Returns a comma-separated string."
   :argument "--repos="
   :reader #'magit-standup--read-repos)
 
-(transient-define-infix magit-standup--author ()
-  :description "Author"
+(defun magit-standup--read-authors (prompt _initial-input _history)
+  "Read author names with `completing-read-multiple'.
+PROMPT is shown to the user.  Returns a comma-separated string."
+  (string-join (completing-read-multiple
+                prompt (ensure-list magit-standup-authors))
+               ","))
+
+(transient-define-infix magit-standup--authors ()
+  :description "Authors"
   :class 'transient-option
   :shortarg "-a"
-  :argument "--author="
+  :argument "--authors="
+  :reader #'magit-standup--read-authors
   :init-value (lambda (obj)
                 (unless (oref obj value)
-                  (oset obj value magit-standup-author))))
+                  (oset obj value
+                        (when magit-standup-authors
+                          (string-join (ensure-list magit-standup-authors) ","))))))
 
 (transient-define-suffix magit-standup--run ()
   "Run the standup with the selected options."
@@ -312,9 +329,10 @@ PROMPT is shown to the user.  Returns a comma-separated string."
          (since (transient-arg-value "--since=" args))
          (repos-str (transient-arg-value "--repos=" args))
          (repos (when repos-str (split-string repos-str ",")))
-         (author (transient-arg-value "--author=" args)))
+         (authors-str (transient-arg-value "--authors=" args))
+         (authors (when authors-str (split-string authors-str "," t))))
     (magit-standup--display
-     (magit-standup--gather since repos author))))
+     (magit-standup--gather since repos authors))))
 
 ;;;###autoload (autoload 'magit-standup "magit-standup" nil t)
 (transient-define-prefix magit-standup ()
@@ -322,7 +340,7 @@ PROMPT is shown to the user.  Returns a comma-separated string."
   ["Options"
    (magit-standup--since)
    (magit-standup--repos)
-   (magit-standup--author)]
+   (magit-standup--authors)]
   ["Actions"
    ("s" "Show standup" magit-standup--run)])
 

--- a/magit-standup.el
+++ b/magit-standup.el
@@ -64,7 +64,10 @@ When nil, search with unlimited depth."
 
 (defcustom magit-standup-author nil
   "Author name or email to filter commits by.
-When nil, the result of `git config user.email' is used."
+When nil, the result of `git config user.email' is used.  The
+`--author=' option of the `magit-standup' menu overrides this
+value for one run.  Git applies `.mailmap' to the filter, so use
+the mapped identity when a repository has a `.mailmap' file."
   :type '(choice (const :tag "From git config" nil)
           (string :tag "Author name/email"))
   :group 'magit-standup)
@@ -157,22 +160,24 @@ the org link prefix string, or nil for plain text."
               hash)
             rest)))
 
-(defun magit-standup--resolve-author (repo-path)
+(defun magit-standup--resolve-author (repo-path &optional author)
   "Return the author string to filter commits by in REPO-PATH.
-Uses `magit-standup-author' if set, otherwise falls back to
-`git config user.email' in REPO-PATH."
+Uses AUTHOR if set, then `magit-standup-author', otherwise falls
+back to `git config user.email' in REPO-PATH."
   (let ((default-directory (file-name-as-directory repo-path)))
-    (or magit-standup-author
+    (or author
+        magit-standup-author
         (magit-git-string "config" "user.email")
         (user-error "Cannot determine author for %s; set `magit-standup-author' or git config user.email" repo-path))))
 
-(defun magit-standup--collect-commits (repo-path since-date)
+(defun magit-standup--collect-commits (repo-path since-date &optional author)
   "Collect commits from REPO-PATH since SINCE-DATE.
+AUTHOR, when non-nil, overrides `magit-standup-author'.
 Returns an alist of (BRANCH-NAME . COMMITS) where COMMITS is a
 list of raw commit strings with hash and message separated by a
 null byte."
   (let* ((default-directory (file-name-as-directory repo-path))
-         (author (magit-standup--resolve-author repo-path))
+         (author (magit-standup--resolve-author repo-path author))
          (branches (magit-git-lines "branch" "--format=%(refname:short)")))
     (mapcar (lambda (branch)
               (cons branch
@@ -220,10 +225,11 @@ LINK-PREFIX is the org link prefix string, or nil for plain text."
                  (mapconcat #'identity formatted "\n")))))
    repo-commits ""))
 
-(defun magit-standup--gather (&optional since-date repos)
+(defun magit-standup--gather (&optional since-date repos author)
   "Gather recent commits across all configured repositories.
 SINCE-DATE, when non-nil, overrides the computed since date.
 REPOS, when non-nil, overrides `magit-standup-repos'.
+AUTHOR, when non-nil, overrides `magit-standup-author'.
 Returns an alist of (REPO-PATH . BRANCH-COMMITS) suitable for
 `magit-standup--format-org'."
   (let* ((since-date (or since-date (magit-standup--since-date)))
@@ -232,7 +238,7 @@ Returns an alist of (REPO-PATH . BRANCH-COMMITS) suitable for
                     (list (magit-toplevel)))))
     (mapcar (lambda (repo)
               (cons repo
-                    (magit-standup--collect-commits repo since-date)))
+                    (magit-standup--collect-commits repo since-date author)))
             repos)))
 
 (defun magit-standup-quit ()
@@ -288,6 +294,15 @@ PROMPT is shown to the user.  Returns a comma-separated string."
   :argument "--repos="
   :reader #'magit-standup--read-repos)
 
+(transient-define-infix magit-standup--author ()
+  :description "Author"
+  :class 'transient-option
+  :shortarg "-a"
+  :argument "--author="
+  :init-value (lambda (obj)
+                (unless (oref obj value)
+                  (oset obj value magit-standup-author))))
+
 (transient-define-suffix magit-standup--run ()
   "Run the standup with the selected options."
   :key "s"
@@ -296,16 +311,18 @@ PROMPT is shown to the user.  Returns a comma-separated string."
   (let* ((args (transient-args 'magit-standup))
          (since (transient-arg-value "--since=" args))
          (repos-str (transient-arg-value "--repos=" args))
-         (repos (when repos-str (split-string repos-str ","))))
+         (repos (when repos-str (split-string repos-str ",")))
+         (author (transient-arg-value "--author=" args)))
     (magit-standup--display
-     (magit-standup--gather since repos))))
+     (magit-standup--gather since repos author))))
 
 ;;;###autoload (autoload 'magit-standup "magit-standup" nil t)
 (transient-define-prefix magit-standup ()
   "Show a menu for generating standup notes."
   ["Options"
    (magit-standup--since)
-   (magit-standup--repos)]
+   (magit-standup--repos)
+   (magit-standup--author)]
   ["Actions"
    ("s" "Show standup" magit-standup--run)])
 

--- a/test/magit-standup-test.el
+++ b/test/magit-standup-test.el
@@ -100,7 +100,20 @@
     (let ((magit-standup-author nil))
       (spy-on 'magit-git-string :and-return-value nil)
       (expect (magit-standup--resolve-author "/tmp/repo")
-              :to-throw 'user-error))))
+              :to-throw 'user-error)))
+
+  (it "prefers the AUTHOR argument over magit-standup-author"
+    (let ((magit-standup-author "alice"))
+      (spy-on 'magit-git-string)
+      (expect (magit-standup--resolve-author "/tmp/repo" "carol")
+              :to-equal "carol")
+      (expect 'magit-git-string :not :to-have-been-called)))
+
+  (it "prefers the AUTHOR argument over git config user.email"
+    (let ((magit-standup-author nil))
+      (spy-on 'magit-git-string :and-return-value "bob@example.com")
+      (expect (magit-standup--resolve-author "/tmp/repo" "carol")
+              :to-equal "carol"))))
 
 (describe "magit-standup--collect-commits"
   (it "sets default-directory to the repo path"
@@ -113,7 +126,17 @@
       (magit-standup--collect-commits "/tmp/my-repo" "2026-01-05")
       (expect captured-dirs :not :to-be nil)
       (dolist (dir captured-dirs)
-        (expect dir :to-equal "/tmp/my-repo/")))))
+        (expect dir :to-equal "/tmp/my-repo/"))))
+
+  (it "passes the AUTHOR argument to git log"
+    (let ((magit-standup-author "alice")
+          captured-args)
+      (spy-on 'magit-git-lines :and-call-fake
+              (lambda (&rest args)
+                (push args captured-args)
+                (when (equal (car args) "branch") (list "main"))))
+      (magit-standup--collect-commits "/tmp/my-repo" "2026-01-05" "carol")
+      (expect (car captured-args) :to-contain "--author=carol"))))
 
 (describe "magit-standup--resolve-repos"
   :var (tmpdir)
@@ -251,7 +274,7 @@
       (magit-standup--gather "2026-02-01")
       (expect 'magit-standup--since-date :not :to-have-been-called)
       (expect 'magit-standup--collect-commits
-              :to-have-been-called-with "/tmp/a" "2026-02-01")))
+              :to-have-been-called-with "/tmp/a" "2026-02-01" nil)))
 
   (it "uses provided repos instead of configured ones"
     (let ((magit-standup-repos '("/tmp/should-not-use")))
@@ -265,7 +288,7 @@
       (expect 'magit-standup--since-date :not :to-have-been-called)
       (expect 'magit-standup--resolve-repos :not :to-have-been-called)
       (expect 'magit-standup--collect-commits
-              :to-have-been-called-with "/tmp/override" "2026-03-01"))))
+              :to-have-been-called-with "/tmp/override" "2026-03-01" nil))))
 
 (describe "magit-standup--display"
   (after-each

--- a/test/magit-standup-test.el
+++ b/test/magit-standup-test.el
@@ -81,43 +81,50 @@
              "/home/user/repo" '("stale-branch"))
             :to-be nil)))
 
-(describe "magit-standup--resolve-author"
-  (it "uses magit-standup-author when set"
-    (let ((magit-standup-author "alice"))
+(describe "magit-standup--resolve-authors"
+  (it "uses magit-standup-authors when set"
+    (let ((magit-standup-authors '("alice" "carol")))
       (spy-on 'magit-git-string)
-      (magit-standup--resolve-author "/tmp/repo")
+      (expect (magit-standup--resolve-authors "/tmp/repo")
+              :to-equal '("alice" "carol"))
       (expect 'magit-git-string :not :to-have-been-called)))
 
+  (it "accepts a single string in magit-standup-authors"
+    (let ((magit-standup-authors "alice"))
+      (spy-on 'magit-git-string)
+      (expect (magit-standup--resolve-authors "/tmp/repo")
+              :to-equal '("alice"))))
+
   (it "falls back to git config user.email"
-    (let ((magit-standup-author nil))
+    (let ((magit-standup-authors nil))
       (spy-on 'magit-git-string :and-return-value "bob@example.com")
-      (expect (magit-standup--resolve-author "/tmp/repo")
-              :to-equal "bob@example.com")
+      (expect (magit-standup--resolve-authors "/tmp/repo")
+              :to-equal '("bob@example.com"))
       (expect 'magit-git-string
               :to-have-been-called-with "config" "user.email")))
 
   (it "signals error when no author can be determined"
-    (let ((magit-standup-author nil))
+    (let ((magit-standup-authors nil))
       (spy-on 'magit-git-string :and-return-value nil)
-      (expect (magit-standup--resolve-author "/tmp/repo")
+      (expect (magit-standup--resolve-authors "/tmp/repo")
               :to-throw 'user-error)))
 
-  (it "prefers the AUTHOR argument over magit-standup-author"
-    (let ((magit-standup-author "alice"))
+  (it "prefers the AUTHORS argument over magit-standup-authors"
+    (let ((magit-standup-authors '("alice")))
       (spy-on 'magit-git-string)
-      (expect (magit-standup--resolve-author "/tmp/repo" "carol")
-              :to-equal "carol")
+      (expect (magit-standup--resolve-authors "/tmp/repo" '("carol" "dave"))
+              :to-equal '("carol" "dave"))
       (expect 'magit-git-string :not :to-have-been-called)))
 
-  (it "prefers the AUTHOR argument over git config user.email"
-    (let ((magit-standup-author nil))
+  (it "prefers the AUTHORS argument over git config user.email"
+    (let ((magit-standup-authors nil))
       (spy-on 'magit-git-string :and-return-value "bob@example.com")
-      (expect (magit-standup--resolve-author "/tmp/repo" "carol")
-              :to-equal "carol"))))
+      (expect (magit-standup--resolve-authors "/tmp/repo" '("carol"))
+              :to-equal '("carol")))))
 
 (describe "magit-standup--collect-commits"
   (it "sets default-directory to the repo path"
-    (let ((magit-standup-author "alice")
+    (let ((magit-standup-authors '("alice"))
           captured-dirs)
       (spy-on 'magit-git-lines :and-call-fake
               (lambda (&rest _)
@@ -128,15 +135,19 @@
       (dolist (dir captured-dirs)
         (expect dir :to-equal "/tmp/my-repo/"))))
 
-  (it "passes the AUTHOR argument to git log"
-    (let ((magit-standup-author "alice")
+  (it "gives git log one --author flag for each author"
+    (let ((magit-standup-authors '("alice"))
           captured-args)
       (spy-on 'magit-git-lines :and-call-fake
               (lambda (&rest args)
                 (push args captured-args)
                 (when (equal (car args) "branch") (list "main"))))
-      (magit-standup--collect-commits "/tmp/my-repo" "2026-01-05" "carol")
-      (expect (car captured-args) :to-contain "--author=carol"))))
+      (magit-standup--collect-commits "/tmp/my-repo" "2026-01-05"
+                                      '("carol" "dave"))
+      (expect (flatten-tree (car captured-args))
+              :to-contain "--author=carol")
+      (expect (flatten-tree (car captured-args))
+              :to-contain "--author=dave"))))
 
 (describe "magit-standup--resolve-repos"
   :var (tmpdir)


### PR DESCRIPTION
In repositories where the author gets overwritten by `.mailmap` the tool did not return any commits.

This feature adds a new transient option to override that value on demand, but you can also set it with

```elisp
(setq magit-standup-authors (list "john@doe.com"
                                  "johndoe@example.com"))
```